### PR TITLE
ユーザーアイコンの横に6px余白を追加

### DIFF
--- a/src/assets2/scss/_template.scss
+++ b/src/assets2/scss/_template.scss
@@ -377,6 +377,7 @@ templateItem:
           display: table-cell;
           vertical-align: middle;
           width: 20px;
+          padding: 0 6px;
           &:after{
             @include icon( down );
             position: relative;


### PR DESCRIPTION
https://trello.com/c/MUJqusPR/18--