### PR TITLE
シリーズナビ内の縦中横用文字への変換処理を改善

### DIFF
--- a/src/assets2/js/CG2-articleSeriesNav.js
+++ b/src/assets2/js/CG2-articleSeriesNav.js
@@ -67,10 +67,10 @@ window.addEventListener( 'DOMContentLoaded', function () {
 
     // ”1.5”が"1"と"5"に別れるのを防ぐために小数もマッチさせる
     var _replaceTargetRe = /([0-9]+\.?[0-9]*)/g;
-    var _replaceFunc = function ( str, ptn1 ) {
+    var _replaceFunc = function ( match, p1 ) {
 
       // Arrayもオブジェクトなので、数値にキャストせずずるく利用する
-      return lookup[ptn1] || ptn1;
+      return lookup[p1] || p1;
 
     };
 

--- a/src/assets2/js/CG2-articleSeriesNav.js
+++ b/src/assets2/js/CG2-articleSeriesNav.js
@@ -65,12 +65,12 @@ window.addEventListener( 'DOMContentLoaded', function () {
 
   var replaceNumber = function () {
 
-    var _replaceTargetRe = /([0-9]+)/g;
+    // ”1.5”が"1"と"5"に別れるのを防ぐために小数もマッチさせる
+    var _replaceTargetRe = /([0-9]+\.?[0-9]*)/g;
     var _replaceFunc = function ( str, ptn1 ) {
 
-      var num = ptn1|0;
-
-      return lookup[num] || num;
+      // Arrayもオブジェクトなので、数値にキャストせずずるく利用する
+      return lookup[ptn1] || ptn1;
 
     };
 


### PR DESCRIPTION
"1.5"みたいな小数が"1"-"."-"5"とふたつの数字として扱われる仕組みだったので、それを回避させる。

fixes #51