### PR TITLE
対応ブラウザとコードを2017年3月現在の状況をふまえて更新

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,10 +46,6 @@ gulp.task( 'clean', function () {
 gulp.task( 'copy-font', function () {
 
   return gulp.src( [
-          './src/assets2/font/zero-width.eot',
-          './src/assets2/font/zero-width.otf',
-          './src/assets2/font/zero-width.svg',
-          './src/assets2/font/zero-width.ttf',
           './src/assets2/font/zero-width.woff'
          ] )
          .pipe( gulp.dest( './build/assets2/font/' ) );
@@ -128,6 +124,7 @@ gulp.task( 'iconfont', function () {
   return gulp.src( [ './src/assets2/font/codegrid-icon/*.svg' ] )
   .pipe( iconfont( {
     fontName: fontName,
+    formats: ['woff', 'woff2'],
     appendCodepoints: true
   } ) )
   .on( 'glyphs', function( glyphs, options ) {
@@ -154,6 +151,7 @@ gulp.task( 'numfont', function () {
   return gulp.src( [ './src/assets2/font/codegrid-num/*.svg' ] )
   .pipe( iconfont( {
     fontName: fontName,
+    formats: ['woff', 'woff2'],
     fontHeight: 256,
     descent: 24
   } ) )

--- a/package.json
+++ b/package.json
@@ -46,9 +46,8 @@
     "underscore": "^1.8.3"
   },
   "browserslist": [
-    "ie >= 9",
-    "safari >= 7",
-    "ios >= 7",
-    "android >= 4"
+    "ie >= 11",
+    "safari >= 10",
+    "ios >= 10"
   ]
 }

--- a/src/assets2/font/codegrid-icon/_icon.scss
+++ b/src/assets2/font/codegrid-icon/_icon.scss
@@ -19,11 +19,8 @@ tag:
 
 @font-face {
   font-family: "<%= fontName %>";
-  src: url('<%= fontPath %><%= fontName %>.eot');
-  src: url('<%= fontPath %><%= fontName %>.eot?#iefix') format('embedded-opentype'),
-    url('<%= fontPath %><%= fontName %>.woff') format('woff'),
-    url('<%= fontPath %><%= fontName %>.ttf') format('truetype'),
-    url('<%= fontPath %><%= fontName %>.svg#<%= fontName %>') format('svg');
+  src: url('<%= fontPath %><%= fontName %>.woff2') format('woff2'),
+       url('<%= fontPath %><%= fontName %>.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/assets2/scss/_2_basic.scss
+++ b/src/assets2/scss/_2_basic.scss
@@ -10,10 +10,7 @@
 
 @font-face {
   font-family: 'zeroWidth';
-  src:url('../font/zero-width.eot');
-  src:url('../font/zero-width.eot#iefix') format('embedded-opentype'),
-      url('../font/zero-width.woff') format('woff'),
-      url('../font/zero-width.ttf') format('truetype');
+  src: url('../font/zero-width.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/assets2/scss/_components.scss
+++ b/src/assets2/scss/_components.scss
@@ -199,10 +199,6 @@ progress
   }
 }
 
-@-webkit-keyframes button--loading {
-    0% { -webkit-transform: rotate(   0deg ); }
-  100% { -webkit-transform :rotate( 360deg ); }
-}
 @keyframes button--loading {
     0% { transform: rotate(   0deg ); }
   100% { transform :rotate( 360deg ); }

--- a/src/assets2/scss/_icon.scss
+++ b/src/assets2/scss/_icon.scss
@@ -251,11 +251,8 @@ cat-discussion
 
 @font-face {
   font-family: "codegrid-icon";
-  src: url('../font/codegrid-icon.eot');
-  src: url('../font/codegrid-icon.eot?#iefix') format('embedded-opentype'),
-    url('../font/codegrid-icon.woff') format('woff'),
-    url('../font/codegrid-icon.ttf') format('truetype'),
-    url('../font/codegrid-icon.svg#codegrid-icon') format('svg');
+  src: url('../font/codegrid-icon.woff2') format('woff2'),
+       url('../font/codegrid-icon.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/assets2/scss/_template.scss
+++ b/src/assets2/scss/_template.scss
@@ -247,12 +247,9 @@ templateItem:
   @include max-screen( $breakpoint-middle ) {
     height: 35px;
     padding: 0 10px;
-    -webkit-transition: -webkit-transform .4s;
-            transition:         transform .4s;
+    transition: transform .4s;
     html.js-drawer--show & {
-      -webkit-transform: translateX( -100% ) translateX( 50px );
-          -ms-transform: translateX( -100% ) translateX( 50px );
-              transform: translateX( -100% ) translateX( 50px );
+      transform: translateX( -100% ) translateX( 50px );
     }
   }
   @include print () {
@@ -908,8 +905,6 @@ templateItem:
   float: left;
   width: 54.99%;
   ul{
-    -webkit-column-count: 2;
-    -moz-column-count: 2;
     column-count: 2;
     list-style: none;
     margin: 0;
@@ -1161,30 +1156,22 @@ $drawerLeft: 50px;
   width: 100%;
   height: 100%;
   background: rgba( 0, 0, 0, 0 );
-  -webkit-transform: translate3d( ( -$drawerLeft ), 0, 0 );
-      -ms-transform: translateX( ( -$drawerLeft ) );
-          transform: translate3d( ( -$drawerLeft ), 0, 0 );
-  -webkit-transition: -webkit-transform .4s;
-          transition:         transform .4s;
+  transform: translate3d( ( -$drawerLeft ), 0, 0 );
+  transition: transform .4s;
 }
 .CG2-drawer__panel, x::-ms-fill {
   transform: translateX( ( -$drawerLeft ) ); /* IE10, 11, avoid using GPU feature */
 }
 
 html:not( .js-drawer--show ) .CG2-drawer__panel {
-  -webkit-animation-name: zIndexOut;
-          animation-name: zIndexOut;
-  -webkit-animation-duration: .4s;
-          animation-duration: .4s;
-  -webkit-animation-iteration-count: 1;
-          animation-iteration-count: 1;
+  animation-name: zIndexOut;
+  animation-duration: .4s;
+  animation-iteration-count: 1;
 }
 html.js-drawer--show .CG2-drawer__panel {
   margin-left: 0;
   z-index: $z-pageHeader - 1;
-  -webkit-transform: translateX( -100% );
-      -ms-transform: translateX( -100% );
-          transform: translateX( -100% );
+  transform: translateX( -100% );
 }
 html.js-drawer--dragging,
 html.js-drawer--dragging * {
@@ -1193,8 +1180,7 @@ html.js-drawer--dragging * {
   cursor: grabbing;
 }
 html:not( .js-drawer--dragging ) .CG2-drawer__panel {
-  -webkit-transition: -webkit-transform .4s, margin .1s;
-          transition:         transform .4s, margin .1s;
+  transition: transform .4s, margin .1s;
 }
 .CG2-drawer__panel:before {
   content: '';
@@ -1220,8 +1206,7 @@ html:not( .js-drawer--dragging ) .CG2-drawer__panel {
   box-sizing: border-box;
   min-height: 100%;
   box-shadow: -2px 2px 4px rgba( 0, 0, 0, 0 );
-  -webkit-transition: box-shadow .4s;
-          transition: box-shadow .4s;
+  transition: box-shadow .4s;
 }
 html.js-drawer--show .CG2-drawer__panelBody {
   box-shadow: -2px 2px 4px rgba( 0, 0, 0, 0.3 );
@@ -1244,15 +1229,11 @@ html.js-drawer--show .CG2-drawer__panelBody {
   bottom: 0;
   left: 0;
   background: rgba( 0, 0, 0, 0 );
-  -webkit-transition: background .4s;
-          transition: background .4s;
+    transition: background .4s;
   html:not( .js-drawer--show ) & {
-    -webkit-animation-name: bgOut;
-            animation-name: bgOut;
-    -webkit-animation-duration: .4s;
-            animation-duration: .4s;
-    -webkit-animation-iteration-count: 1;
-            animation-iteration-count: 1;
+    animation-name: bgOut;
+    animation-duration: .4s;
+    animation-iteration-count: 1;
   }
   html.js-drawer--show & {
     z-index: $z-pageHeader - 2;
@@ -1261,21 +1242,9 @@ html.js-drawer--show .CG2-drawer__panelBody {
 }
 
 
-@-webkit-keyframes bgOut {
-    0% { z-index:  $z-pageHeader - 2; }
-   99% { z-index:  $z-pageHeader - 2; }
-  100% { z-index: -1; }
-}
-
 @keyframes bgOut {
     0% { z-index:  $z-pageHeader - 2; }
    99% { z-index:  $z-pageHeader - 2; }
-  100% { z-index: -1; }
-}
-
-@-webkit-keyframes zIndexOut {
-    0% { z-index:  $z-pageHeader - 1; }
-   99% { z-index:  $z-pageHeader - 1; }
   100% { z-index: -1; }
 }
 

--- a/src/assets2/scss/codegrid-ui.scss
+++ b/src/assets2/scss/codegrid-ui.scss
@@ -1,10 +1,7 @@
 @font-face {
   font-family: "codegrid-num";
-  src: url('../font/codegrid-num.eot');
-  src: url('../font/codegrid-num.eot?#iefix') format('embedded-opentype'),
-    url('../font/codegrid-num.woff') format('woff'),
-    url('../font/codegrid-num.ttf') format('truetype'),
-    url('../font/codegrid-num.svg#codegrid-num') format('svg');
+  src: url('../font/codegrid-num.woff2') format('woff2'),
+       url('../font/codegrid-num.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Google Analyticsを見るにIE11以上、Safari, iOSともに10以上でよさそうなので。

fixes #68