### PR TITLE
FirefoxでseriesListアンホバー時のartifactsを解消

### DIFF
--- a/src/assets2/scss/_components.scss
+++ b/src/assets2/scss/_components.scss
@@ -1727,6 +1727,7 @@ tag:
     .CG2-seriesList__coverImage{
       @include blurry();
       transition: transform 1s;
+      will-change: opacity; // fixing Firefox causing artifacts on unhover
       .CG2-seriesList__item:hover &,
       .CG2-seriesList__item:focus &{
         transform: scale( 1.4, 1.4 );


### PR DESCRIPTION
背景画像＋opacity＋overflow:hiddenなものがscale()でぐにぐにと変わる際に起こっていた。
will-change: opacityでなんか解消した（transformなどはだめ）のでそれを採用

fixes #74