### PR TITLE
breakpoint-middle時にヘッダのロゴが左に寄らないのを修正

### DIFF
--- a/src/assets2/scss/_template.scss
+++ b/src/assets2/scss/_template.scss
@@ -273,6 +273,9 @@ templateItem:
     height: 100%;
     padding: 0 28px;
     margin: 0 auto;
+    @include max-screen( $breakpoint-middle ) {
+      padding: 0 28px 0 0;
+    }
   }
     .CG2-pageHeader__logo{
       margin: 0 30px 0 0;


### PR DESCRIPTION
デザインなのかなと思ったけど、コードを見るにpadding-leftの調整が抜けちゃった感がある。

fixes #75