### PR TITLE
アプリ内通知バーのスタイルを追加

### DIFF
--- a/src/assets2/scss/_components.scss
+++ b/src/assets2/scss/_components.scss
@@ -2805,6 +2805,8 @@ templateItem:
   - true
 ---
 
+アプリケーション内のメッセージを表示させたいときに使用。
+
 ## メッセージのみ
 
 ```html
@@ -2817,8 +2819,10 @@ templateItem:
 
 ## メッセージとアクション
 
+リンクなどの動線を入れたい場合は、`CG2-inAppNotificationBar--withAction`を付与する。
+
 ```html
-<div class="CG2-inAppNotificationBar">
+<div class="CG2-inAppNotificationBar CG2-inAppNotificationBar--withAction">
   <div class="CG2-inAppNotificationBar__message">
     <span class="CG2-icon-exclamation-circle"></span>
     現在、未購読状態です
@@ -2862,7 +2866,7 @@ templateItem:
   padding: 16px;
   display: flex;
   align-content: center;
-  justify-content: space-between;
+  justify-content: center;
   background-color: #bbb;
   &.CG2-inAppNotificationBar--level1{
     background-color: #F03C3C;
@@ -2873,6 +2877,10 @@ templateItem:
   &.CG2-inAppNotificationBar--level3{
     background-color: #14C850;
   }
+  &.CG2-inAppNotificationBar--withAction{
+    justify-content: space-between;
+  }
+
   @include max-screen( $breakpoint-small ) {
     font-size: 14px;
   }
@@ -2886,13 +2894,8 @@ templateItem:
         margin-right: 5px;
       }
     }
-    &:only-child {
-      margin: 0 auto;
-    }
   }
-  .CG2-inAppNotificationBar__action{
-    display: block;
-  }
+  .CG2-inAppNotificationBar__action{}
 
 
 /* ==========================================================================

--- a/src/assets2/scss/_components.scss
+++ b/src/assets2/scss/_components.scss
@@ -2792,6 +2792,110 @@ tag:
 
 
 /* ==========================================================================
+   CG2-inAppNotificationBar
+   ========================================================================== */
+/*
+---
+name: inAppNotificationBar
+category:
+  - Templates
+tag:
+  - app-item
+templateItem:
+  - true
+---
+
+## メッセージのみ
+
+```html
+<div class="CG2-inAppNotificationBar CG2-inAppNotificationBar--level2">
+  <div class="CG2-inAppNotificationBar__message">
+    ログアウトしました
+  </div>
+</div>
+```
+
+## メッセージとアクション
+
+```html
+<div class="CG2-inAppNotificationBar">
+  <div class="CG2-inAppNotificationBar__message">
+    <span class="CG2-icon-exclamation-circle"></span>
+    現在、未購読状態です
+  </div>
+  <div class="CG2-inAppNotificationBar__action">
+    <a class="CG2-transparentButton" href="#">設定へ</a>
+  </div>
+</div>
+```
+
+## カラーバリエーション
+
+```html
+<div class="CG2-inAppNotificationBar">
+  <div class="CG2-inAppNotificationBar__message">
+    レベルなし
+  </div>
+</div>
+<div class="CG2-inAppNotificationBar CG2-inAppNotificationBar--level1">
+  <div class="CG2-inAppNotificationBar__message">
+    レベル1
+  </div>
+</div>
+<div class="CG2-inAppNotificationBar CG2-inAppNotificationBar--level2">
+  <div class="CG2-inAppNotificationBar__message">
+    レベル2
+  </div>
+</div>
+<div class="CG2-inAppNotificationBar CG2-inAppNotificationBar--level3">
+  <div class="CG2-inAppNotificationBar__message">
+    レベル3
+  </div>
+</div>
+```
+
+*/
+.CG2-inAppNotificationBar{
+  color: #FFF;
+  font-size: 16px;
+  font-weight: bold;
+  padding: 16px;
+  display: flex;
+  align-content: center;
+  justify-content: space-between;
+  background-color: #bbb;
+  &.CG2-inAppNotificationBar--level1{
+    background-color: #F03C3C;
+  }
+  &.CG2-inAppNotificationBar--level2{
+    background-color: #f0b428;
+  }
+  &.CG2-inAppNotificationBar--level3{
+    background-color: #14C850;
+  }
+  @include max-screen( $breakpoint-small ) {
+    font-size: 14px;
+  }
+}
+  .CG2-inAppNotificationBar__message{
+    span[class^="CG2-icon-"]{
+      font-size: 28px;
+      margin-right: 10px;
+      @include max-screen( $breakpoint-small ) {
+        font-size: 20px;
+        margin-right: 5px;
+      }
+    }
+    &:only-child {
+      margin: 0 auto;
+    }
+  }
+  .CG2-inAppNotificationBar__action{
+    display: block;
+  }
+
+
+/* ==========================================================================
    CG2-articleNotice
    ========================================================================== */
 /*


### PR DESCRIPTION
![screen shot 2017-04-12 at 01 14 05](https://cloud.githubusercontent.com/assets/413984/24919252/03ac0d22-1f1e-11e7-9189-77dcb5ccad78.png)

iOSアプリで未購読状態を通知するものと、新しい管理画面のデザインで使いそうなので追加。
.CG2-articleNoticeをコピーして、flexboxを利用したものに変更。

iOSアプリの未購読状態の場合は灰色なので、デフォルトの色を灰色に設定。
未購読状態通知は左にメッセージ、右にボタンが来るので、直下に要素が2つある場合は左右に配置し
メッセージのみの場合は真ん中に。

issue: #73