### PR TITLE
設定画面のアイテムが狭幅のときにはみ出てしまっていたのを修正

### DIFF
--- a/src/assets2/scss/_components.scss
+++ b/src/assets2/scss/_components.scss
@@ -4660,7 +4660,7 @@ tag:
 
 .CG2-settings{
   margin: 0 -40px;
-  @include max-screen( 1054px ) {
+  @include screen(　$breakpoint-middle + 1, 1054px ) {
     margin: 0 -20px;
   }
   @include max-screen( $breakpoint-middle ) {


### PR DESCRIPTION
メディアクエリの上書きがうまくできてなかったのでそれを直す。
マジックナンバーはそのままにした。

fixes #79