### PR TITLE
.editorconfigを追加

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+end_of_line = lf
+indent_style = space
+indent_size = 2
+
+[src/assets2/font/codegrid-{icon,num}/*.svg]
+indent_style = tab
+end_of_line = crlf
+
+[src/assets2/vendor/_prism.scss]
+indent_style = tab


### PR DESCRIPTION
基本的には

* UTF-8
* LF
* 2 spaces

という感じ。

ただフォント用SVG（出力したもの？）やPrism用CSSなどが違っていた。
いちおう例外を設けている。Prismはアップデートも含めて直してもいいかと思っている。

issue: #87