### PR TITLE
アプリ内通知バーのスマホ幅スタイルを調整

### DIFF
--- a/src/assets2/scss/_components.scss
+++ b/src/assets2/scss/_components.scss
@@ -2883,6 +2883,7 @@ templateItem:
 
   @include max-screen( $breakpoint-small ) {
     font-size: 14px;
+    padding: 10px;
   }
 }
   .CG2-inAppNotificationBar__message{


### PR DESCRIPTION
パディングを小さくした。
fixes #95 

![screen shot 2017-06-06 at 20 19 34](https://cloud.githubusercontent.com/assets/413984/26826842/83702432-4af5-11e7-9b27-61c1d97b8005.png)
