### PR TITLE
削除してしまってたmqpacker用の記述を復活

### DIFF
--- a/src/assets2/scss/_2_basic.scss
+++ b/src/assets2/scss/_2_basic.scss
@@ -15,6 +15,11 @@
   font-style: normal;
 }
 
+/* mqpackerが意図した順番にソースを並び替えるためのおまじない */
+@include max-screen( $breakpoint-base )   { _x { _x : 0 } }
+@include max-screen( $breakpoint-middle ) { _x { _x : 0 } }
+@include max-screen( $breakpoint-small )  { _x { _x : 0 } }
+
 /* modifier: align
    ========================================================================== */
 .CG2--alignLeft   {text-align:left !important; }


### PR DESCRIPTION
これがなくてmqpackerの順番がおかしくなっていた。
とりあえず復活させて、レイアウト崩れを戻す。

fixes #107, fixes #103, fixes #104, fixes #105