### PR TITLE
コラム内の画像がはみ出るのを抑制

### DIFF
--- a/src/assets2/scss/_components.scss
+++ b/src/assets2/scss/_components.scss
@@ -3842,6 +3842,9 @@ article.CG2-article{
         margin: 0;
       }
     }
+    img {
+      max-width: 100%;
+    }
   }
     .Column h1,
     .Column-title{

--- a/src/assets2/scss/_components.scss
+++ b/src/assets2/scss/_components.scss
@@ -3497,6 +3497,13 @@ tag:
     <p>Autoprefixerに関しては、次の記事を参照してください。<br><a href="#">「ビルドツールアラカルト」</a>シリーズ</p>
   </aside>
 
+  <div class="Column">
+    <h1>コラムタイトル</h1>
+    <p>テキスト<a href="#">リンク</a>てきすと<code>code</code>テキストてきすとテキストてきすと</p>
+    <p><img src="http://img.pxgrid.net/1000x200"></p>
+    <p>テキスト<a href="#">リンク</a>てきすと<code>code</code>テキストてきすとテキストてきすと</p>
+  </div>
+
 </article>
 ```
 


### PR DESCRIPTION
なんだか「旧Jade 用」と書かれたブロック内にしか`.Column`のスタイルがない…
整理するのはべつにやるとして、とりあえずmax-widthを追加。