### PR TITLE
iPhone専用デモiframeラッパーに高さを指定

### DIFF
--- a/src/assets2/scss/_components.scss
+++ b/src/assets2/scss/_components.scss
@@ -4739,14 +4739,15 @@ tag:
 
 ```
 
-動く demo として、iframe を埋め込むことができる
+## iframe埋め込み
 
-iframeには、
+作ったデモをiframeで埋め込める。
+以下の追加クラスで、高さの指定が可能。
 
 - CG2-livecode__frame--small
 - CG2-livecode__frame--large
 
-を追加クラスとして明示することも可能。その場合それぞれ、iframeの高さが190px、590pxとなる。
+なお、iPhoneの場合はiframeが伸びる仕様を回避するため、高さが固定される。
 
 ```html
 <section class="CG2-livecode">
@@ -4768,7 +4769,6 @@ iframeには、
   </div>
 </section>
 ```
-
 */
 section.CG2-livecode{
   margin: 2em 0;

--- a/src/assets2/scss/_components.scss
+++ b/src/assets2/scss/_components.scss
@@ -4912,6 +4912,11 @@ section.CG2-livecode{
       width: 100%;
     }
   }
+  // iPhoneでiframeが伸びてしまう問題の対処用
+  // iPhoneの場合、JavaScriptでiframeをこれで動的に包む
+  .CG2-livecode__body--inner {
+    height: 40vh;
+  }
 
 
 /* ==========================================================================


### PR DESCRIPTION
現在のデフォルトの高さ390pxは長すぎるように感じたので、40vhに。

デモはあくまで文章の補佐なので、主張しすぎるのは避けたいので小さめに。

![simulator screen shot sep 14 2017 21 58 25](https://user-images.githubusercontent.com/413984/30432495-d2f99f92-999c-11e7-8036-db1014be334c.png)

vhなので、横向きのときも画面内に収まる。

![simulator screen shot sep 14 2017 22 06 23](https://user-images.githubusercontent.com/413984/30432502-d6025864-999c-11e7-83d6-819bbc451e95.png)
