### PR TITLE
印刷時の記事名や見出しのフォントを変更

### DIFF
--- a/src/assets2/scss/_components-app.scss
+++ b/src/assets2/scss/_components-app.scss
@@ -4300,3 +4300,28 @@ tag:
     }
   }
 }
+
+
+/* ==========================================================================
+   Chromeで印刷時に日本語が消えるバグへの対応
+   ========================================================================== */
+/*
+Chrome 66くらいから確認中。
+指定したら消えているフォント：
+  * Klee, YuMincho, Hiragino Mincho ProN
+  * Osaka
+*/
+// 影響が多いのは記事（校正時に印刷する）なので、とりあえずそこだけ
+@media print {
+  .CG2-articleHeader__series,
+  .CG2-articleHeader__title,
+  header.CG2-articleTOC__header h1,
+  article.CG2-article > h2 {
+    font-family: serif !important;
+  }
+  article.CG2-article pre,
+  article.CG2-article code {
+    // 日本語だけヒラギノとかになるようにsans-serifを指定
+    font-family: Consolas, Monaco, Menlo, sans-serif !important;
+  }
+}


### PR DESCRIPTION
Chromeで印刷（プレビュー）時に日本語が消えるバグがあり、それへの暫定的対処

closes: #127