### PR TITLE
aigisのプレビューから上下paddingを削除

### DIFF
--- a/src/aigis-template/aigis_assets/css/theme.css
+++ b/src/aigis-template/aigis_assets/css/theme.css
@@ -195,7 +195,9 @@ tag: latest
 }
 
 .aigis-preview {
-  padding: 16px;
+  /* padding: 16px; */
+  display: flow-root;
+  padding: 0 20px;
   margin-top: 10px;
 }
 


### PR DESCRIPTION
代わりにdisplay: flow-rootを入れてmargin-collapsingをなくす。
左右のpaddingはとりあえずのこしとく。

fixes #125 