### PR TITLE
seriesList：スマホ幅でも記事名と回数の間をじゅうぶんにとる

### DIFF
--- a/src/assets2/scss/_components-shared.scss
+++ b/src/assets2/scss/_components-shared.scss
@@ -1777,7 +1777,7 @@ button.CG2-seriesList__itemUtilButton--favAdded {
 
   @include max-screen( $breakpoint-middle ) {
     font-size: 14px;
-    padding-right: 10px;
+    padding-right: 14px;
 
     &:first-child {
       padding-left: 10px;


### PR DESCRIPTION
「前編」「漢字から始まるタイトル」とかの場合、現在の隙間では誤読する可能性があり、コロンなどをいれて対策していた。
コンテンツ側での対策はうれしくないので、間を広げる。

fixes: #131